### PR TITLE
Specify platform and fix volume references in docker-compose

### DIFF
--- a/production/monitoring/docker-compose.yaml
+++ b/production/monitoring/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
     external: true
 
 volumes:
-  grafana:
+  grafana-data:
     name: grafana-data
 
 services:

--- a/production/monitoring/docker-compose.yaml
+++ b/production/monitoring/docker-compose.yaml
@@ -74,6 +74,7 @@ services:
       - "traefik.docker.network=proxy"
 
   pve-exporter:
+    platform: linux/arm64
     image: prompve/prometheus-pve-exporter:latest@sha256:79a5598906697b1a5a006d09f0200528a77c6ff1568faf018539ac65824454df
     container_name: pve-exporter
     restart: unless-stopped

--- a/production/monitoring/docker-compose.yaml
+++ b/production/monitoring/docker-compose.yaml
@@ -1,5 +1,13 @@
 name: monitoring
 
+networks:
+  proxy:
+    external: true
+
+volumes:
+  grafana:
+    name: grafana-data
+
 services:
 
   prometheus:
@@ -63,7 +71,7 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
-      - grafana:/var/lib/grafana
+      - grafana-data:/var/lib/grafana
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.grafana.rule=Host(`grafana.binarybraids.com`)"
@@ -305,8 +313,6 @@ configs:
             summary: Kubernetes pod crash looping (instance {{ $$labels.instance }})
             description: "Pod {{ $$labels.namespace }}/{{ $$labels.pod }} is crash looping\n  VALUE = {{ $$value }}\n  LABELS = {{ $$labels }}"
 
-
-
   alertmanager.yml:
     content: |
         global:
@@ -329,9 +335,5 @@ configs:
           user: monitor@pve
           password: "${PROXMOX_EXPORTER_PASSWORD}"
 
-networks:
-  proxy:
-    external: true
 
-volumes:
-  grafana:
+

--- a/production/monitoring/docker-compose.yaml
+++ b/production/monitoring/docker-compose.yaml
@@ -5,6 +5,10 @@ networks:
     external: true
 
 volumes:
+  prometheus-data:
+    name: prometheus-data
+  alertmanager-data:
+    name: alertmanager-data
   grafana-data:
     name: grafana-data
 
@@ -19,7 +23,8 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
-      - /docker/prometheus:/etc/prometheus
+      - prometheus-data:/etc/prometheus
+      - prometheus-data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.retention.time=7d'
@@ -47,7 +52,8 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
-      - /docker/alertmanager:/etc/alertmanager
+      - alertmanager-data:/etc/alertmanager
+      - alertmanager-data:/alertmanager
     command:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
     configs:

--- a/production/monitoring/docker-compose.yaml
+++ b/production/monitoring/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.prometheus.rule=Host(`prometheus.binarybraids.com`)"
-      - "traefik.http.routers.prometheus.entrypoints=https"
+      - "traefik.http.routers.prometheus.entrypoints=websecure"
       - "traefik.http.routers.prometheus.tls=true"
       - "traefik.http.routers.prometheus.service=prometheus"
       - "traefik.http.services.prometheus.loadbalancer.server.port=9090"
@@ -62,7 +62,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.alertmanager.rule=Host(`alertmanager.binarybraids.com`)"
-      - "traefik.http.routers.alertmanager.entrypoints=https"
+      - "traefik.http.routers.alertmanager.entrypoints=websecure"
       - "traefik.http.routers.alertmanager.tls=true"
       - "traefik.http.routers.alertmanager.service=alertmanager"
       - "traefik.http.services.alertmanager.loadbalancer.server.port=9093"
@@ -81,7 +81,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.grafana.rule=Host(`grafana.binarybraids.com`)"
-      - "traefik.http.routers.grafana.entrypoints=https"
+      - "traefik.http.routers.grafana.entrypoints=websecure"
       - "traefik.http.routers.grafana.tls=true"
       - "traefik.http.routers.grafana.service=grafana"
       - "traefik.http.services.grafana.loadbalancer.server.port=3000"
@@ -104,7 +104,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.pve-exporter.rule=Host(`pve-exporter.binarybraids.com`)"
-      - "traefik.http.routers.pve-exporter.entrypoints=https"
+      - "traefik.http.routers.pve-exporter.entrypoints=websecure"
       - "traefik.http.routers.pve-exporter.tls=true"
       - "traefik.http.routers.pve-exporter.service=pve-exporter"
       - "traefik.http.services.pve-exporter.loadbalancer.server.port=9221"


### PR DESCRIPTION
Update the docker-compose configuration to specify the platform for the pve-exporter service and correct volume references for Grafana, Prometheus, and Alertmanager. Clean up network and volume definitions, ensuring proper entrypoints for Traefik routers.