### PR TITLE
Add external volume definitions for Prometheus, Grafana, and Alertmanager in Docker Compose

### DIFF
--- a/production/docker-volume-backup/docker-compose.yaml
+++ b/production/docker-volume-backup/docker-compose.yaml
@@ -7,6 +7,12 @@ networks:
 volumes:
   home-assistant-data:
     external: true
+  prometheus-data:
+    external: true
+  grafana-data:
+    external: true
+  alertmanager-data:
+    external: true
 
 services:
   docker-volume-backup:
@@ -24,3 +30,6 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - home-assistant-data:/backup/home-assistant-data:ro
+      - prometheus-data:/backup/prometheus-data:ro
+      - grafana-data:/backup/grafana-data:ro
+      - alertmanager-data:/backup/alertmanager-data:ro


### PR DESCRIPTION
Introduce external volume definitions for Prometheus, Grafana, and Alertmanager to the Docker Compose configuration, enabling better data management for these services.