### PR TITLE
Enable insecure extension access for stable-diffusion-forge-webui in Docker Compose

### DIFF
--- a/production/ai/docker-compose.yaml
+++ b/production/ai/docker-compose.yaml
@@ -103,7 +103,7 @@ services:
     runtime: nvidia
     restart: unless-stopped
     environment:
-      - ARGS=--listen
+      - ARGS=--listen --enable-insecure-extension-access
       - UI=forge
     networks:
       - proxy


### PR DESCRIPTION
Modify the Docker Compose configuration to allow insecure extension access for the stable-diffusion-forge-webui service.